### PR TITLE
Don't return to "readBlock" when "Try" fails.

### DIFF
--- a/flate/prefix.go
+++ b/flate/prefix.go
@@ -20,8 +20,8 @@ var (
 )
 
 type rangeCode struct {
-	base uint32 // Starting base offset of the range
-	bits uint32 // Bit-width of a subsequent integer to add to base offset
+	base int // Starting base offset of the range
+	bits uint // Bit-width of a subsequent integer to add to base offset
 }
 
 type prefixCode struct {
@@ -45,7 +45,7 @@ func initPrefixLUTs() {
 		if i < 4 {
 			nb = 0
 		}
-		lenLUT[i] = rangeCode{base: uint32(base), bits: uint32(nb)}
+		lenLUT[i] = rangeCode{base: int(base), bits: uint(nb)}
 		base += 1 << nb
 	}
 	lenLUT[len(lenLUT)-1] = rangeCode{base: 258, bits: 0}
@@ -56,7 +56,7 @@ func initPrefixLUTs() {
 		if i < 2 {
 			nb = 0
 		}
-		distLUT[i] = rangeCode{base: uint32(base), bits: uint32(nb)}
+		distLUT[i] = rangeCode{base: int(base), bits: uint(nb)}
 		base += 1 << nb
 	}
 

--- a/flate/reader.go
+++ b/flate/reader.go
@@ -168,10 +168,7 @@ readLiteral:
 		}
 
 		// Read the literal symbol.
-		litSym, ok := fr.rd.TryReadSymbol(&fr.litTree)
-		if !ok {
-			litSym = fr.rd.ReadSymbol(&fr.litTree)
-		}
+		litSym := fr.rd.DoReadSymbol(&fr.litTree)
 		switch {
 		case litSym < endBlockSym:
 			fr.dict.WriteByte(byte(litSym))
@@ -183,28 +180,19 @@ readLiteral:
 		case litSym < maxNumLitSyms:
 			// Decode the copy length.
 			rec := lenLUT[litSym-257]
-			extra, ok := fr.rd.TryReadBits(uint(rec.bits))
-			if !ok {
-				extra = fr.rd.ReadBits(uint(rec.bits))
-			}
-			fr.cpyLen = int(rec.base) + int(extra)
+			extra := fr.rd.DoReadBits(rec.bits)
+			fr.cpyLen = rec.base + extra
 
 			// Read the distance symbol.
-			distSym, ok := fr.rd.TryReadSymbol(&fr.distTree)
-			if !ok {
-				distSym = fr.rd.ReadSymbol(&fr.distTree)
-			}
+			distSym := fr.rd.DoReadSymbol(&fr.distTree)
 			if distSym >= maxNumDistSyms {
 				panic(ErrCorrupt)
 			}
 
 			// Decode the copy distance.
 			rec = distLUT[distSym]
-			extra, ok = fr.rd.TryReadBits(uint(rec.bits))
-			if !ok {
-				extra = fr.rd.ReadBits(uint(rec.bits))
-			}
-			fr.dist = int(rec.base) + int(extra)
+			extra = fr.rd.DoReadBits(rec.bits)
+			fr.dist = rec.base + extra
 
 			goto copyDistance
 		default:


### PR DESCRIPTION
This saves a trip and a branch if there isn't enough bits available.

I also took out all conversions in "readBlock", though that didn't give any measurable difference.

```
benchmark                              old ns/op     new ns/op     delta
BenchmarkDecodeDigitsSpeed1e4-4        171940        215635        +25.41%
BenchmarkDecodeDigitsSpeed1e5-4        1501811       1931875       +28.64%
BenchmarkDecodeDigitsSpeed1e6-4        14568562      19561093      +34.27%
BenchmarkDecodeDigitsDefault1e4-4      165902        209304        +26.16%
BenchmarkDecodeDigitsDefault1e5-4      1362442       1697436       +24.59%
BenchmarkDecodeDigitsDefault1e6-4      13319185      16616284      +24.75%
BenchmarkDecodeDigitsCompress1e4-4     173700        206644        +18.97%
BenchmarkDecodeDigitsCompress1e5-4     1356080       1698376       +25.24%
BenchmarkDecodeDigitsCompress1e6-4     13133361      16372422      +24.66%
BenchmarkDecodeTwainSpeed1e4-4         168946        203608        +20.52%
BenchmarkDecodeTwainSpeed1e5-4         1451828       1677522       +15.55%
BenchmarkDecodeTwainSpeed1e6-4         12799408      15986753      +24.90%
BenchmarkDecodeTwainDefault1e4-4       156335        192007        +22.82%
BenchmarkDecodeTwainDefault1e5-4       1123643       1395297       +24.18%
BenchmarkDecodeTwainDefault1e6-4       10366843      12915718      +24.59%
BenchmarkDecodeTwainCompress1e4-4      156745        192109        +22.56%
BenchmarkDecodeTwainCompress1e5-4      1115888       1387081       +24.30%
BenchmarkDecodeTwainCompress1e6-4      10364155      12877965      +24.25%

benchmark                              old MB/s     new MB/s     speedup
BenchmarkDecodeDigitsSpeed1e4-4        58.16        46.37        0.80x
BenchmarkDecodeDigitsSpeed1e5-4        66.59        51.76        0.78x
BenchmarkDecodeDigitsSpeed1e6-4        68.64        51.12        0.74x
BenchmarkDecodeDigitsDefault1e4-4      60.28        47.78        0.79x
BenchmarkDecodeDigitsDefault1e5-4      73.40        58.91        0.80x
BenchmarkDecodeDigitsDefault1e6-4      75.08        60.18        0.80x
BenchmarkDecodeDigitsCompress1e4-4     57.57        48.39        0.84x
BenchmarkDecodeDigitsCompress1e5-4     73.74        58.88        0.80x
BenchmarkDecodeDigitsCompress1e6-4     76.14        61.08        0.80x
BenchmarkDecodeTwainSpeed1e4-4         59.19        49.11        0.83x
BenchmarkDecodeTwainSpeed1e5-4         68.88        59.61        0.87x
BenchmarkDecodeTwainSpeed1e6-4         78.13        62.55        0.80x
BenchmarkDecodeTwainDefault1e4-4       63.97        52.08        0.81x
BenchmarkDecodeTwainDefault1e5-4       89.00        71.67        0.81x
BenchmarkDecodeTwainDefault1e6-4       96.46        77.43        0.80x
BenchmarkDecodeTwainCompress1e4-4      63.80        52.05        0.82x
BenchmarkDecodeTwainCompress1e5-4      89.61        72.09        0.80x
BenchmarkDecodeTwainCompress1e6-4      96.49        77.65        0.80x
```

