### PR TITLE
Add go.mod and go.sum files to support Go modules.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/dsnet/compress
+
+require (
+	github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780
+	github.com/klauspost/compress v1.4.1
+	github.com/klauspost/cpuid v1.2.0 // indirect
+	github.com/ulikunitz/xz v0.5.6
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780 h1:tFh1tRc4CA31yP6qDcu+Trax5wW5GuMxvkIba07qVLY=
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
+github.com/klauspost/compress v1.4.1 h1:8VMb5+0wMgdBykOV96DwNwKFQ+WTI4pzYURP99CcB9E=
+github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
+github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
+github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=


### PR DESCRIPTION
In order to work well with [Go modules][1] a package should have `go.mod` and `go.sum` files and semantic version tags on release versions. This commit adds those files. No functional changes are intended.

Assuming you accept this change, I recommend that you also run `git tag v0.0.1 master ; git push origin v0.0.1` after it is merged, to start the release history. If the API of the package is considered stable, you could instead use `v1.0.0`, but at that point module users will expect breaking changes to increment the major version. I don't have a clear sense of how much this package is maintained, so `v0` would be a safe default for now.

[1]: https://github.com/golang/go/wiki/Modules