### PR TITLE
Fix Travis script to be hermetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,29 @@ before_install:
   - (cd zstd-1.3.2 && sudo make install)
   - rm -rf zstd-1.3.2
   - sudo ldconfig
-before_script:
-  - go get github.com/golang/lint/golint
-  - go get honnef.co/go/tools/cmd/staticcheck
+  - mkdir /tmp/go1.12
+  - curl -L -s https://dl.google.com/go/go1.12.linux-amd64.tar.gz | tar -zxf - -C /tmp/go1.12 --strip-components 1
+  - unset GOROOT
+  - (GO111MODULE=on /tmp/go1.12/bin/go mod vendor)
+  - (cd /tmp && GO111MODULE=on /tmp/go1.12/bin/go get golang.org/x/lint/golint@8f45f776aaf18cebc8d65861cc70c33c60471952)
+  - (cd /tmp && GO111MODULE=on /tmp/go1.12/bin/go get honnef.co/go/tools/cmd/staticcheck@2019.1)
 matrix:
   include:
-    - go: 1.7.x
-      script: go test -v -race ./...
-    - go: 1.x
-      script: ./ztest.sh
+    - go: 1.9.x
+      script:
+        - go test -v -race ./...
+    - go: 1.10.x
+      script:
+        - go test -v -race ./...
+    - go: 1.11.x
+      script:
+        - go test -v -race ./...
+    - go: 1.12.x
+      script:
+        - ./ztest.sh
     - go: master
-      script: go test -v -race ./...
+      script:
+        - go test -v -race ./...
   allow_failures:
     - go: master
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Run the command:
 
 ```go get -u github.com/dsnet/compress```
 
-This library requires `Go1.7` or higher in order to build.
+This library requires `Go1.9` or higher in order to build.
 
 
 ## Packages ##

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/dsnet/compress
+
+go 1.9
+
+require (
+	github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780
+	github.com/klauspost/compress v1.4.1
+	github.com/klauspost/cpuid v1.2.0 // indirect
+	github.com/ulikunitz/xz v0.5.6
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780 h1:tFh1tRc4CA31yP6qDcu+Trax5wW5GuMxvkIba07qVLY=
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
+github.com/klauspost/compress v1.4.1 h1:8VMb5+0wMgdBykOV96DwNwKFQ+WTI4pzYURP99CcB9E=
+github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
+github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
+github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/ztest.sh
+++ b/ztest.sh
@@ -22,13 +22,23 @@ if [[ ! -z "$RET_TEST" ]]; then echo "$RET_TEST"; echo; fi
 echo -e "${BOLD}staticcheck${RESET}"
 RET_SCHK=$(staticcheck \
 	-ignore "
-		github.com/dsnet/compress/internal/prefix/*.go:SA4016
 		github.com/dsnet/compress/brotli/*.go:SA4016
+		github.com/dsnet/compress/brotli/*.go:S1023
+		github.com/dsnet/compress/brotli/*.go:U1000
+		github.com/dsnet/compress/bzip2/*.go:S1023
+		github.com/dsnet/compress/flate/*.go:U1000
+		github.com/dsnet/compress/internal/cgo/lzma/*.go:SA4000
+		github.com/dsnet/compress/internal/prefix/*.go:S1004
+		github.com/dsnet/compress/internal/prefix/*.go:S1023
+		github.com/dsnet/compress/internal/prefix/*.go:SA4016
+		github.com/dsnet/compress/internal/tool/bench/*.go:S1007
+		github.com/dsnet/compress/xflate/internal/meta/*.go:S1023
 	" ./... 2>&1)
 if [[ ! -z "$RET_SCHK" ]]; then echo "$RET_SCHK"; echo; fi
 
 echo -e "${BOLD}lint${RESET}"
 RET_LINT=$(golint ./... 2>&1 |
+	egrep -v "^vendor/" |
 	egrep -v "should have comment(.*)or be unexported" |
 	egrep -v "^(.*)type name will be used as(.*)by other packages" |
 	egrep -v "^brotli/transform.go:(.*)replace i [+]= 1 with i[+]{2}" |


### PR DESCRIPTION
Fix the Travis script to be hermetic such that the test result is
agnostic to when in time it is run. That is, all of the dependencies
are explicitly versioned.